### PR TITLE
fixed the problem the duplication in the candidates 

### DIFF
--- a/completion-plugin.tcl
+++ b/completion-plugin.tcl
@@ -174,7 +174,7 @@ proc ::completion::scan_all_completions {} {
     ::completion::add_user_customcompletions
     ::completion::add_user_monolithiclist
     set ::loaded_libs {} ;#clear the loaded_libs because it was only used to scan the right objects located in multi-object distributions
-    set ::all_externals [lsort $::all_externals]
+    set ::all_externals [lsort -unique $::all_externals]
     ::completion::add_special_messages ;#AFTER sorting
     
     set finalTime [clock milliseconds]


### PR DESCRIPTION
Context:  https://github.com/HenriAugusto/completion-plugin/issues/36#issuecomment-1457359449_

This PR fixes the duplication in the candidates when the external dylibs exist for each of different architectures.